### PR TITLE
Update genesis.json to work with Geth 1.6

### DIFF
--- a/config/genesis.json
+++ b/config/genesis.json
@@ -1,10 +1,16 @@
 {
+    "config": {
+        "chainId": 1337,
+        "homesteadBlock": 0,
+        "eip155Block": 0,
+        "eip158Block": 0
+    },
     "nonce": "0x0000000000000042",
-    "timestamp": "0x0",
+    "timestamp": "0x00",
     "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "extraData": "0x0",
+    "extraData": "0x00",
     "gasLimit": "0x8000000",
-    "difficulty": "0x1",
+    "difficulty": "0x01",
     "mixhash": "0x0000000000000000000000000000000000000000000000000000000000000000",
     "coinbase": "0x5DFE021F45f00Ae83B0aA963bE44A1310a782fCC",
     "alloc": {


### PR DESCRIPTION
As Geth 1.6 was released the changed the requirements for genesis.json such that the file provided does not work. This PR fixes that, and `bin/init` works once again.

Particularly:

- Hex values need to be an even length
- `config` is needed to define if/when hardfork code should be enacted.

See https://github.com/ethereum/go-ethereum/issues/7201 for some more info.